### PR TITLE
set linkActiveClass classes

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -27,6 +27,13 @@ module.exports = {
   },
 
   /*
+  ** Set the link active classes
+  */
+  router: {
+    linkActiveClass: 'active open'
+  },  
+
+  /*
   ** Customize the progress bar color
   */
   loading: { color: '#42A5CC' },


### PR DESCRIPTION
This fixes the following bugs NavItem behaviour
- Nav does not automatically open if the url matches the nav item url
- If a nav child item is clicked on the parent still collapses